### PR TITLE
Remove commit linters from package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -63,8 +63,6 @@
     "eslint-plugin-vue": "^9.9.0",
     "express": "^4.18.2",
     "hygen": "^6.2.11",
-    "imagemin-lint-staged": "^0.5.1",
-    "lint-staged": "^13.1.1",
     "markdownlint-cli": "^0.33.0",
     "npm-run-all": "^4.1.1",
     "sass": "^1.58.0",


### PR DESCRIPTION
Remove these commit linters as they are giving us problems with the docker build. Might reintroduce once we get the dependencies more up to date