### PR TITLE
alpine image needed tzdata installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV UID=998
 ENV PID=100
 ENV GIN_MODE=release
 VOLUME ["/config", "/assets"]
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add ca-certificates tzdata && rm -rf /var/cache/apk/*
 RUN mkdir -p /config; \
     mkdir -p /assets; \
     mkdir -p /api


### PR DESCRIPTION
The alpine image does not have the tzdata package installed by default.

This fixes the issues seen in #80 and #86 